### PR TITLE
feat: Notify the user when no guideline exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://quack-ai.com"><img src="https://uploads-ssl.webflow.com/64a6527708bc7f2ce5fd6b2a/64a654825ed3d444b47c4935_quack-logo%20(copy).png" width="100" height="100"></a>
+  <a href="https://quack-ai.com"><img src="https://quack-ai.com/quack.png" width="100" height="100"></a>
 </p>
 <h1 align="center">
  Quack Companion

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -76,6 +76,11 @@ export function activate(context: vscode.ExtensionContext) {
           ghRepo.id,
         );
 
+        // If no guidelines exists, say it in the console
+        if (guidelines.length === 0) {
+          vscode.window.showInformationMessage("No guidelines specified yet.");
+        }
+
         // Display in the sidebar
         guidelineView._view?.webview.postMessage({
           type: "repo-guidelines",


### PR DESCRIPTION
This PR adds a notification when no guideline has been found and fixes the logo URL in the README.