### PR TITLE
feat: Cache the GitHub & Quack API responses

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "quack-companion",
   "displayName": "Quack Companion",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "license": "Apache-2.0",
   "publisher": "quackai",
   "description": "Your companion for code contributions",

--- a/src/quack.ts
+++ b/src/quack.ts
@@ -13,6 +13,12 @@ export interface QuackGuideline {
 }
 
 export async function fetchRepoGuidelines(repoId: number): Promise<any> {
+  const cachedData = vscode.workspace
+    .getConfiguration()
+    .get("quack-companion.repoGuidelines");
+  if (cachedData) {
+    return cachedData;
+  }
   try {
     // Retrieve the guidelines
     const response: AxiosResponse<any> = await axios.get(
@@ -21,7 +27,14 @@ export async function fetchRepoGuidelines(repoId: number): Promise<any> {
 
     // Handle the response
     if (response.status === 200) {
-      // The request was successful, and you can process the response data here
+      // Save to cache
+      await vscode.workspace
+        .getConfiguration()
+        .update(
+          "quack-companion.repoGuidelines",
+          response.data,
+          vscode.ConfigurationTarget.Global,
+        );
       return response.data;
     } else {
       // The request returned a non-200 status code (e.g., 404)

--- a/src/util/github.ts
+++ b/src/util/github.ts
@@ -25,6 +25,12 @@ export interface GithubIssue {
 }
 
 export async function getRepoDetails(repoName: string): Promise<any> {
+  const cachedData = vscode.workspace
+    .getConfiguration()
+    .get("quack-companion.repoDetails");
+  if (cachedData) {
+    return cachedData;
+  }
   try {
     // Check that it's a public repo
     const response: AxiosResponse<any> = await axios.get(
@@ -33,7 +39,14 @@ export async function getRepoDetails(repoName: string): Promise<any> {
 
     // Handle the response
     if (response.status === 200) {
-      // The request was successful, and you can process the response data here
+      // Save to cache
+      await vscode.workspace
+        .getConfiguration()
+        .update(
+          "quack-companion.repoDetails",
+          response.data,
+          vscode.ConfigurationTarget.Global,
+        );
       return response.data;
     } else {
       // The request returned a non-200 status code (e.g., 404)

--- a/svelte/components/Guideline.svelte
+++ b/svelte/components/Guideline.svelte
@@ -4,9 +4,7 @@ This program is licensed under the Apache License 2.0.
 See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details. -->
 
 <script lang="ts">
-    import type internal from "stream";
     import { onMount } from "svelte";
-
     type quackGuideline = { id: number, order: number, repo_id: number, title: string, details: string, created_at: string, updated_at: string, completed: boolean, expanded: boolean };
 
     let submitted = false;


### PR DESCRIPTION
This PR introduces the following modifications:
- use VSCode cache for GitHub repo details and guideline fetching
- bumps the extension version