### PR TITLE
docs: Updates the copyright year

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,10 +124,12 @@ This data collection is done using [Posthog](https://posthog.com/) and can be:
 
 ## Copying & distribution
 
-Copyright (C) 2023, Quack AI.
+Copyright (C) 2023-2024, Quack AI.
 
 This program is licensed under the Apache License 2.0.
 See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
+
+[![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fquack-ai%2Fquack-companion-vscode.svg?type=large&issueType=license)](https://app.fossa.com/projects/git%2Bgithub.com%2Fquack-ai%2Fquack-companion-vscode?ref=badge_large&issueType=license)
 
 ## Contributing
 

--- a/src/activation/activate.ts
+++ b/src/activation/activate.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Quack AI.
+// Copyright (C) 2023-2024, Quack AI.
 
 // This program is licensed under the Apache License 2.0.
 // See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.

--- a/src/activation/environmentSetup.ts
+++ b/src/activation/environmentSetup.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Quack AI.
+// Copyright (C) 2023-2024, Quack AI.
 
 // This program is licensed under the Apache License 2.0.
 // See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.

--- a/src/commands/assistant.ts
+++ b/src/commands/assistant.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Quack AI.
+// Copyright (C) 2023-2024, Quack AI.
 
 // This program is licensed under the Apache License 2.0.
 // See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.

--- a/src/commands/authentication.ts
+++ b/src/commands/authentication.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Quack AI.
+// Copyright (C) 2023-2024, Quack AI.
 
 // This program is licensed under the Apache License 2.0.
 // See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.

--- a/src/commands/diagnostics.ts
+++ b/src/commands/diagnostics.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Quack AI.
+// Copyright (C) 2023-2024, Quack AI.
 
 // This program is licensed under the Apache License 2.0.
 // See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.

--- a/src/commands/guidelines.ts
+++ b/src/commands/guidelines.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Quack AI.
+// Copyright (C) 2023-2024, Quack AI.
 
 // This program is licensed under the Apache License 2.0.
 // See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Quack AI.
+// Copyright (C) 2023-2024, Quack AI.
 
 // This program is licensed under the Apache License 2.0.
 // See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.

--- a/src/util/analytics.ts
+++ b/src/util/analytics.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Quack AI.
+// Copyright (C) 2023-2024, Quack AI.
 
 // This program is licensed under the Apache License 2.0.
 // See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.

--- a/src/util/github.ts
+++ b/src/util/github.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Quack AI.
+// Copyright (C) 2023-2024, Quack AI.
 
 // This program is licensed under the Apache License 2.0.
 // See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.

--- a/src/util/quack.ts
+++ b/src/util/quack.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Quack AI.
+// Copyright (C) 2023-2024, Quack AI.
 
 // This program is licensed under the Apache License 2.0.
 // See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.

--- a/src/util/session.ts
+++ b/src/util/session.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Quack AI.
+// Copyright (C) 2023-2024, Quack AI.
 
 // This program is licensed under the Apache License 2.0.
 // See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.

--- a/src/util/vscode.ts
+++ b/src/util/vscode.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Quack AI.
+// Copyright (C) 2023-2024, Quack AI.
 
 // This program is licensed under the Apache License 2.0.
 // See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.

--- a/src/webviews/guidelineView.ts
+++ b/src/webviews/guidelineView.ts
@@ -1,4 +1,4 @@
-// Copyright (C) 2023, Quack AI.
+// Copyright (C) 2023-2024, Quack AI.
 
 // This program is licensed under the Apache License 2.0.
 // See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.


### PR DESCRIPTION
This PR updates the copyright year in header notice & adds a FOSSA license badge to README.