### PR TITLE
refactor(util): use fetch instead of axios for HTTP requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -434,7 +434,6 @@
     ]
   },
   "dependencies": {
-    "axios": "^1.6.7",
     "clipboardy": "^4.0.0",
     "marked": "^12.0.0",
     "node-machine-id": "^1.1.12",

--- a/src/util/github.ts
+++ b/src/util/github.ts
@@ -4,7 +4,6 @@
 // See LICENSE or go to <https://www.apache.org/licenses/LICENSE-2.0> for full license details.
 
 import * as vscode from "vscode";
-import axios, { AxiosResponse } from "axios";
 import { getCurrentRepoName } from "./session";
 
 export interface GitHubRepo {
@@ -25,19 +24,16 @@ interface GithubUser {
   login: string;
 }
 
-export async function getUser(githubtoken: string): Promise<GithubUser> {
+export async function getUser(githubToken: string): Promise<GithubUser> {
   try {
     // Check that it's a public repo
-    const response: AxiosResponse<any> = await axios.get(
-      `https://api.github.com/user`,
-      {
-        headers: { Authorization: `Bearer ${githubtoken}` },
-      },
-    );
+    const response = await fetch(`https://api.github.com/user`, {
+      headers: { Authorization: `Bearer ${githubToken}` },
+    });
 
     // Handle the response
-    if (response.status === 200) {
-      return response.data;
+    if (response.ok) {
+      return (await response.json()) as GithubUser;
     } else {
       // The request returned a non-200 status code (e.g., 404)
       // Show an error message or handle the error accordingly
@@ -64,14 +60,13 @@ export async function getRepoDetails(
 ): Promise<GitHubRepo> {
   try {
     // Check that it's a public repo
-    const response: AxiosResponse<any> = await axios.get(
-      `https://api.github.com/repos/${repoName}`,
-      { headers: { Authorization: `Bearer ${githubToken}` } },
-    );
+    const response = await fetch(`https://api.github.com/repos/${repoName}`, {
+      headers: { Authorization: `Bearer ${githubToken}` },
+    });
 
     // Handle the response
-    if (response.status === 200) {
-      return response.data;
+    if (response.ok) {
+      return (await response.json()) as GitHubRepo;
     } else {
       throw new Error(`GitHub API returned status code ${response.status}`);
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -494,7 +494,7 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
-axios@^1.6.2, axios@^1.6.7:
+axios@^1.6.2:
   version "1.6.7"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.7.tgz#7b48c2e27c96f9c68a2f8f31e2ab19f59b06b0a7"
   integrity sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==


### PR DESCRIPTION
This PR removes axios as a direct dependency and use fetch syntax instead for HTTP requests.